### PR TITLE
Only uses sonarcube on ibm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
 
 script: 
   - npm run lint && npm run test
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -z "$TRAVIS_TAG" ]; then sonar-scanner; fi # sonar only on non-PRs
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_REPO_SLUG" == "ibm/qpylib" ]; then sonar-scanner; fi # sonar only on non-PRs
 
 after_success:
   - if [[ $TRAVIS_TAG ]]; then


### PR DESCRIPTION
previously builds fail on forks, this change allows travis to run on a fork.