### PR TITLE
Change from npm install to npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 
 before_script:
   - export DISPLAY=:99.0
-  - npm install
+  - npm ci
 
 services:
   - xvfb


### PR DESCRIPTION
Issue highlighted here: https://stackoverflow.com/questions/45022048/why-does-npm-install-rewrite-package-lock-json

Currently we use `npm install` as part of our CI build - this will overwrite the lock file and pull down the latest dependencies, resulting in two builds potentially being different with no code changes.

This change uses `npm ci` instead - this uses only the lock file to ensure it is pulling down the same versions of dependencies each time, allowing reproducible builds. If `package.json` is out of sync with `package-lock.json` an error will be thrown.