### PR TITLE
Update qappfw.js with logic statement to change struts url syntax based on UP version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           run: npm run test
       - name: SonarQube scan
-        if: github.event_name != 'release' && github.repository == 'IBM/qjslib'
+        if: github.event_name != 'release' && github.repository == 'IBM/qjslib' && github.ref == 'refs/heads/master'
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/src/qappfw.js
+++ b/src/qappfw.js
@@ -316,7 +316,7 @@ class QRadar {
             throw new Error("You must supply an AQL string");
         }
         // Creates variables for fetching qradar version, removing the dots and taking the first 6 characters from it, i.e. 202164
-        var get_qradar_version = window.QRADAR_VERSION.replaceAll(".","");
+        var get_qradar_version = top.QRADAR_VERSION.replaceAll(".","");
         var qradar_version = get_qradar_version.substring(0,6);
         if (qradar_version >= 202164)
         {
@@ -351,7 +351,7 @@ class QRadar {
             throw new Error("You must supply an AQL string");
         }
         // Creates variables for fetching qradar version, removing the dots and taking the first 6 characters from it, i.e. 202164
-        var get_qradar_version = window.QRADAR_VERSION.replaceAll(".","");
+        var get_qradar_version = top.QRADAR_VERSION.replaceAll(".","");
         var qradar_version = get_qradar_version.substring(0,6);
         if (qradar_version >= 202164)
         {

--- a/src/qappfw.js
+++ b/src/qappfw.js
@@ -294,11 +294,6 @@ class QRadar {
             "do/assetprofile/AssetDetails?dispatch=viewAssetDetailsFromIp&listName=vulnList" +
             "&domainId=0&ipAddress=" + ipAddress, openWindow === false ? "ASSETS" : null);
     }
-    
-    isUP4AndAbove() {
-        // Creates variables for fetching qradar version, removing the dots and taking the first 6 characters from it, i.e. 202164
-        
-    }
 
     /**
      * Runs an event search with the specified AQL string, either in a new window or the Event Viewer tab.
@@ -318,7 +313,7 @@ class QRadar {
             throw new Error("You must supply an AQL string");
         }
         // If qradar version is greater than 202164 then it is UP4 or above
-        if (QRadar._isUP4AndAbove() >= 202164)
+        if (QRadar._isUP4AndAbove())
         {
             return QRadar.windowOrTab(
                 "do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
@@ -352,7 +347,7 @@ class QRadar {
             throw new Error("You must supply an AQL string");
         }
         // If qradar version is greater than 202164 then it is UP4 or above
-        if (QRadar._isUP4AndAbove() >= 202164)
+        if (QRadar._isUP4AndAbove())
         {
             return QRadar.windowOrTab(
                 "do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
@@ -799,8 +794,7 @@ class QRadar {
         // Creates variables for fetching qradar version, removing the dots and taking the first 6 characters from it, i.e. 202164
         var fullQradarVersion = top.QRADAR_VERSION.replaceAll(".","");
         var qradarVersion = fullQradarVersion.substring(0,6);
-        return qradarVersion;
-
+        return qradarVersion >= 202164;
     }
 
 }

--- a/src/qappfw.js
+++ b/src/qappfw.js
@@ -8,6 +8,9 @@
 import "core-js/features/promise";
 import "whatwg-fetch";
 
+
+
+
 /**
  * Static class providing utility functions for QRadar
  */
@@ -305,22 +308,35 @@ class QRadar {
      * @throws Error if aql is not supplied or if the search results could not be displayed.
      *
      */
+    
     static openEventSearch(aql, openWindow)
     {
         if (aql == null)
         {
             throw new Error("You must supply an AQL string");
         }
-
-        return QRadar.windowOrTab(
-            "do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
-            "&value(timeRangeType)=aqlTime&value(searchMode)=AQL" +
-            "&value(aql)=" + encodeURIComponent(aql), openWindow === false ? "EVENTVIEWER" : null);
+        // Creates variables for fetching qradar version, removing the dots and taking the first 6 characters from it, i.e. 202164
+        var get_qradar_version = window.QRADAR_VERSION.replaceAll(".","");
+        var qradar_version = get_qradar_version.substring(0,6);
+        if (qradar_version >= 202164)
+        {
+            return QRadar.windowOrTab(
+                "do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
+                "&values['timeRangeType']=aqlTime&values['searchMode']=AQL" +
+                "&values['aql']=" + encodeURIComponent(aql), openWindow === false ? "EVENTVIEWER" : null);
+        }
+        else
+        {
+            return QRadar.windowOrTab(
+                "do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
+                "&values(timeRangeType)=aqlTime&values(searchMode)=AQL" +
+                "&values(aql)=" + encodeURIComponent(aql), openWindow === false ? "EVENTVIEWER" : null);
+        }
     }
 
     /**
      * Runs a flow search with the specified AQL string, either in a new window or the Flow Viewer tab.
-     *
+     * 
      * @param {String} aql - The AQL search string to execute.
      * @param {boolean} [openWindow=true] - If true, open the search in a new window.
      *                                      Otherwise, open in the Flow Viewer tab.
@@ -334,11 +350,23 @@ class QRadar {
         {
             throw new Error("You must supply an AQL string");
         }
-
-        return QRadar.windowOrTab(
-            "do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
-            "&value(timeRangeType)=aqlTime&value(searchMode)=AQL" +
-            "&value(aql)=" + encodeURIComponent(aql), openWindow === false ? "FLOWVIEWER" : null);
+        // Creates variables for fetching qradar version, removing the dots and taking the first 6 characters from it, i.e. 202164
+        var get_qradar_version = window.QRADAR_VERSION.replaceAll(".","");
+        var qradar_version = get_qradar_version.substring(0,6);
+        if (qradar_version >= 202164)
+        {
+            return QRadar.windowOrTab(
+                "do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
+                "&values['timeRangeType']=aqlTime&values['searchMode']=AQL" +
+                "&values['aql']=" + encodeURIComponent(aql), openWindow === false ? "FLOWVIEWER" : null);
+        }
+        else
+        {
+            return QRadar.windowOrTab(
+                "do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
+                "&values(timeRangeType)=aqlTime&values(searchMode)=AQL" +
+                "&values(aql)=" + encodeURIComponent(aql), openWindow === false ? "FLOWVIEWER" : null);
+        }
     }
 
     /**

--- a/src/qappfw.js
+++ b/src/qappfw.js
@@ -8,9 +8,6 @@
 import "core-js/features/promise";
 import "whatwg-fetch";
 
-
-
-
 /**
  * Static class providing utility functions for QRadar
  */
@@ -297,6 +294,11 @@ class QRadar {
             "do/assetprofile/AssetDetails?dispatch=viewAssetDetailsFromIp&listName=vulnList" +
             "&domainId=0&ipAddress=" + ipAddress, openWindow === false ? "ASSETS" : null);
     }
+    
+    isUP4AndAbove() {
+        // Creates variables for fetching qradar version, removing the dots and taking the first 6 characters from it, i.e. 202164
+        
+    }
 
     /**
      * Runs an event search with the specified AQL string, either in a new window or the Event Viewer tab.
@@ -308,23 +310,22 @@ class QRadar {
      * @throws Error if aql is not supplied or if the search results could not be displayed.
      *
      */
-    
+  
     static openEventSearch(aql, openWindow)
     {
         if (aql == null)
         {
             throw new Error("You must supply an AQL string");
         }
-        // Creates variables for fetching qradar version, removing the dots and taking the first 6 characters from it, i.e. 202164
-        var get_qradar_version = top.QRADAR_VERSION.replaceAll(".","");
-        var qradar_version = get_qradar_version.substring(0,6);
-        if (qradar_version >= 202164)
+        // If qradar version is greater than 202164 then it is UP4 or above
+        if (QRadar._isUP4AndAbove() >= 202164)
         {
             return QRadar.windowOrTab(
                 "do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
                 "&values['timeRangeType']=aqlTime&values['searchMode']=AQL" +
                 "&values['aql']=" + encodeURIComponent(aql), openWindow === false ? "EVENTVIEWER" : null);
         }
+        // Else it must be pre UP4 so UP3 and below
         else
         {
             return QRadar.windowOrTab(
@@ -350,16 +351,15 @@ class QRadar {
         {
             throw new Error("You must supply an AQL string");
         }
-        // Creates variables for fetching qradar version, removing the dots and taking the first 6 characters from it, i.e. 202164
-        var get_qradar_version = top.QRADAR_VERSION.replaceAll(".","");
-        var qradar_version = get_qradar_version.substring(0,6);
-        if (qradar_version >= 202164)
+        // If qradar version is greater than 202164 then it is UP4 or above
+        if (QRadar._isUP4AndAbove() >= 202164)
         {
             return QRadar.windowOrTab(
                 "do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
                 "&values['timeRangeType']=aqlTime&values['searchMode']=AQL" +
                 "&values['aql']=" + encodeURIComponent(aql), openWindow === false ? "FLOWVIEWER" : null);
         }
+        // Else it must be pre UP4 so UP3 and below
         else
         {
             return QRadar.windowOrTab(
@@ -793,6 +793,14 @@ class QRadar {
     static _isFormMimeType(requestMimeType)
     {
         return requestMimeType === QRadar.CONTENT_TYPE_FORM;
+    }
+    static _isUP4AndAbove()
+    {
+        // Creates variables for fetching qradar version, removing the dots and taking the first 6 characters from it, i.e. 202164
+        var fullQradarVersion = top.QRADAR_VERSION.replaceAll(".","");
+        var qradarVersion = fullQradarVersion.substring(0,6);
+        return qradarVersion;
+
     }
 
 }

--- a/src/qappfw.js
+++ b/src/qappfw.js
@@ -329,8 +329,8 @@ class QRadar {
         {
             return QRadar.windowOrTab(
                 "do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
-                "&values(timeRangeType)=aqlTime&values(searchMode)=AQL" +
-                "&values(aql)=" + encodeURIComponent(aql), openWindow === false ? "EVENTVIEWER" : null);
+                "&value(timeRangeType)=aqlTime&value(searchMode)=AQL" +
+                "&value(aql)=" + encodeURIComponent(aql), openWindow === false ? "EVENTVIEWER" : null);
         }
     }
 
@@ -364,8 +364,8 @@ class QRadar {
         {
             return QRadar.windowOrTab(
                 "do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
-                "&values(timeRangeType)=aqlTime&values(searchMode)=AQL" +
-                "&values(aql)=" + encodeURIComponent(aql), openWindow === false ? "FLOWVIEWER" : null);
+                "&value(timeRangeType)=aqlTime&value(searchMode)=AQL" +
+                "&value(aql)=" + encodeURIComponent(aql), openWindow === false ? "FLOWVIEWER" : null);
         }
     }
 

--- a/test/qappfwSpec.js
+++ b/test/qappfwSpec.js
@@ -617,7 +617,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openEventSearch("select qid from events");
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
-                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
+                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -626,7 +626,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openEventSearch("select qid from events", zzz);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
-                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
+                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -634,7 +634,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openEventSearch("select qid from events", null);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
-                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
+                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -642,7 +642,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openEventSearch("select qid from events", true);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
-                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
+                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -650,7 +650,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openEventSearch("select qid from events", false);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
-                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
+                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toEqual("EVENTVIEWER");
             });
         });
@@ -669,7 +669,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openFlowSearch("select qid from events");
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
-                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
+                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -678,7 +678,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openFlowSearch("select qid from events", zzz);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
-                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
+                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -686,7 +686,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openFlowSearch("select qid from events", null);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
-                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
+                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -694,7 +694,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openFlowSearch("select qid from events", true);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
-                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
+                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -702,7 +702,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openFlowSearch("select qid from events", false);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
-                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
+                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toEqual("FLOWVIEWER");
             });
         });

--- a/test/qappfwSpec.js
+++ b/test/qappfwSpec.js
@@ -604,6 +604,7 @@ function TestQRadar(QRadar) {
         });
 
         describe("QRadar.openEventSearch", function () {
+            window.QRADAR_VERSION="2021.6.3.20221014123609";
             it("should throw Error if aql is not supplied", function () {
                 expect(function () { QRadar.openEventSearch(); }).toThrowError("You must supply an AQL string");
             });
@@ -616,7 +617,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openEventSearch("select qid from events");
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
-                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
+                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -625,7 +626,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openEventSearch("select qid from events", zzz);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
-                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
+                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -633,7 +634,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openEventSearch("select qid from events", null);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
-                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
+                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -641,7 +642,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openEventSearch("select qid from events", true);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
-                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
+                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -649,12 +650,13 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openEventSearch("select qid from events", false);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
-                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
+                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toEqual("EVENTVIEWER");
             });
         });
 
         describe("QRadar.openFlowSearch", function () {
+            window.QRADAR_VERSION="2021.6.3.20221014123609";
             it("should throw Error if aql is not supplied", function () {
                 expect(function () { QRadar.openFlowSearch(); }).toThrowError("You must supply an AQL string");
             });
@@ -667,7 +669,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openFlowSearch("select qid from events");
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
-                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
+                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -676,7 +678,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openFlowSearch("select qid from events", zzz);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
-                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
+                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -684,7 +686,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openFlowSearch("select qid from events", null);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
-                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
+                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -692,7 +694,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openFlowSearch("select qid from events", true);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
-                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
+                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toBeNull();
             });
 
@@ -700,7 +702,7 @@ function TestQRadar(QRadar) {
                 var mockResult = QRadar.openFlowSearch("select qid from events", false);
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
-                    "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
+                    "&values(timeRangeType)=aqlTime&values(searchMode)=AQL&values(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toEqual("FLOWVIEWER");
             });
         });

--- a/test/qappfwSpec.js
+++ b/test/qappfwSpec.js
@@ -603,7 +603,9 @@ function TestQRadar(QRadar) {
             });
         });
 
+        
         describe("QRadar.openEventSearch", function () {
+            // QRadar.openEventSearch function for QRADAR UP3 and below
             window.QRADAR_VERSION="2021.6.3.20221014123609";
             it("should throw Error if aql is not supplied", function () {
                 expect(function () { QRadar.openEventSearch(); }).toThrowError("You must supply an AQL string");
@@ -653,9 +655,61 @@ function TestQRadar(QRadar) {
                     "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toEqual("EVENTVIEWER");
             });
-        });
+        }, function () {
+            // QRadar.openEventSearch function for QRADAR UP4+
+            window.QRADAR_VERSION="2021.6.4.20221014123609";
+            it("should throw Error if aql is not supplied", function () {
+                expect(function () { QRadar.openEventSearch(); }).toThrowError("You must supply an AQL string");
+            });
+
+            it("should throw Error if aql is null", function () {
+                expect(function () { QRadar.openEventSearch(null); }).toThrowError("You must supply an AQL string");
+            });
+
+            it("should open in window if openWindow is not supplied", function () {
+                var mockResult = QRadar.openEventSearch("select qid from events");
+                expect(mockResult.suppliedUrl).toEqual(
+                    "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
+                    "&values['timeRangeType']=aqlTime&values['searchMode']=AQL&values['aql']=select%20qid%20from%20events");
+                expect(mockResult.suppliedTabName).toBeNull();
+            });
+
+            it("should open in window if openWindow is undefined", function () {
+                var zzz;
+                var mockResult = QRadar.openEventSearch("select qid from events", zzz);
+                expect(mockResult.suppliedUrl).toEqual(
+                    "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
+                    "&values['timeRangeType']=aqlTime&values['searchMode']=AQL&values['aql']=select%20qid%20from%20events");
+                expect(mockResult.suppliedTabName).toBeNull();
+            });
+
+            it("should open in window if openWindow is null", function () {
+                var mockResult = QRadar.openEventSearch("select qid from events", null);
+                expect(mockResult.suppliedUrl).toEqual(
+                    "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
+                    "&values['timeRangeType']=aqlTime&values['searchMode']=AQL&values['aql']=select%20qid%20from%20events");
+                expect(mockResult.suppliedTabName).toBeNull();
+            });
+
+            it("should open in window if openWindow is true", function () {
+                var mockResult = QRadar.openEventSearch("select qid from events", true);
+                expect(mockResult.suppliedUrl).toEqual(
+                    "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
+                    "&values['timeRangeType']=aqlTime&values['searchMode']=AQL&values['aql']=select%20qid%20from%20events");
+                expect(mockResult.suppliedTabName).toBeNull();
+            });
+
+            it("should open in tab if openWindow is false", function () {
+                var mockResult = QRadar.openEventSearch("select qid from events", false);
+                expect(mockResult.suppliedUrl).toEqual(
+                    "https://99.99.99.99/console/do/ariel/arielSearch?appName=EventViewer&pageId=EventList&dispatch=performSearch" +
+                    "&values['timeRangeType']=aqlTime&values['searchMode']=AQL&values['aql']=select%20qid%20from%20events");
+                expect(mockResult.suppliedTabName).toEqual("EVENTVIEWER");
+            });
+        });    
 
         describe("QRadar.openFlowSearch", function () {
+            // QRadar.openFlowSearch function for QRADAR UP3 and below
             window.QRADAR_VERSION="2021.6.3.20221014123609";
             it("should throw Error if aql is not supplied", function () {
                 expect(function () { QRadar.openFlowSearch(); }).toThrowError("You must supply an AQL string");
@@ -703,6 +757,57 @@ function TestQRadar(QRadar) {
                 expect(mockResult.suppliedUrl).toEqual(
                     "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
                     "&value(timeRangeType)=aqlTime&value(searchMode)=AQL&value(aql)=select%20qid%20from%20events");
+                expect(mockResult.suppliedTabName).toEqual("FLOWVIEWER");
+            });
+        }, function () {
+            // QRadar.openFlowSearch function for QRADAR UP4 and upwards
+            window.QRADAR_VERSION="2021.6.4.20221014123609";
+            it("should throw Error if aql is not supplied", function () {
+                expect(function () { QRadar.openFlowSearch(); }).toThrowError("You must supply an AQL string");
+            });
+
+            it("should throw Error if aql is null", function () {
+                expect(function () { QRadar.openFlowSearch(null); }).toThrowError("You must supply an AQL string");
+            });
+
+            it("should open in window if openWindow is not supplied", function () {
+                var mockResult = QRadar.openFlowSearch("select qid from events");
+                expect(mockResult.suppliedUrl).toEqual(
+                    "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
+                    "&values['timeRangeType']=aqlTime&values['searchMode']=AQL&values['aql']=select%20qid%20from%20events");
+                expect(mockResult.suppliedTabName).toBeNull();
+            });
+
+            it("should open in window if openWindow is undefined", function () {
+                var zzz;
+                var mockResult = QRadar.openFlowSearch("select qid from events", zzz);
+                expect(mockResult.suppliedUrl).toEqual(
+                    "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
+                    "&values['timeRangeType']=aqlTime&values['searchMode']=AQL&values['aql']=select%20qid%20from%20events");
+                expect(mockResult.suppliedTabName).toBeNull();
+            });
+
+            it("should open in window if openWindow is null", function () {
+                var mockResult = QRadar.openFlowSearch("select qid from events", null);
+                expect(mockResult.suppliedUrl).toEqual(
+                    "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
+                    "&values['timeRangeType']=aqlTime&values['searchMode']=AQL&values['aql']=select%20qid%20from%20events");
+                expect(mockResult.suppliedTabName).toBeNull();
+            });
+
+            it("should open in window if openWindow is true", function () {
+                var mockResult = QRadar.openFlowSearch("select qid from events", true);
+                expect(mockResult.suppliedUrl).toEqual(
+                    "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
+                    "&values['timeRangeType']=aqlTime&values['searchMode']=AQL&values['aql']=select%20qid%20from%20events");
+                expect(mockResult.suppliedTabName).toBeNull();
+            });
+
+            it("should open in tab if openWindow is false", function () {
+                var mockResult = QRadar.openFlowSearch("select qid from events", false);
+                expect(mockResult.suppliedUrl).toEqual(
+                    "https://99.99.99.99/console/do/ariel/arielSearch?appName=Surveillance&pageId=FlowList&dispatch=performSearch" +
+                    "&values['timeRangeType']=aqlTime&values['searchMode']=AQL&values['aql']=select%20qid%20from%20events");
                 expect(mockResult.suppliedTabName).toEqual("FLOWVIEWER");
             });
         });

--- a/test/qappfwSpec.js
+++ b/test/qappfwSpec.js
@@ -606,7 +606,7 @@ function TestQRadar(QRadar) {
         
         describe("QRadar.openEventSearch", function () {
             // QRadar.openEventSearch function for QRADAR UP3 and below
-            window.QRADAR_VERSION="2021.6.3.20221014123609";
+            top.QRADAR_VERSION="2021.6.3.20221014123609";
             it("should throw Error if aql is not supplied", function () {
                 expect(function () { QRadar.openEventSearch(); }).toThrowError("You must supply an AQL string");
             });
@@ -657,7 +657,7 @@ function TestQRadar(QRadar) {
             });
         }, function () {
             // QRadar.openEventSearch function for QRADAR UP4+
-            window.QRADAR_VERSION="2021.6.4.20221014123609";
+            top.QRADAR_VERSION="2021.6.4.20221014123609";
             it("should throw Error if aql is not supplied", function () {
                 expect(function () { QRadar.openEventSearch(); }).toThrowError("You must supply an AQL string");
             });
@@ -710,7 +710,7 @@ function TestQRadar(QRadar) {
 
         describe("QRadar.openFlowSearch", function () {
             // QRadar.openFlowSearch function for QRADAR UP3 and below
-            window.QRADAR_VERSION="2021.6.3.20221014123609";
+            top.QRADAR_VERSION="2021.6.3.20221014123609";
             it("should throw Error if aql is not supplied", function () {
                 expect(function () { QRadar.openFlowSearch(); }).toThrowError("You must supply an AQL string");
             });
@@ -761,7 +761,7 @@ function TestQRadar(QRadar) {
             });
         }, function () {
             // QRadar.openFlowSearch function for QRADAR UP4 and upwards
-            window.QRADAR_VERSION="2021.6.4.20221014123609";
+            top.QRADAR_VERSION="2021.6.4.20221014123609";
             it("should throw Error if aql is not supplied", function () {
                 expect(function () { QRadar.openFlowSearch(); }).toThrowError("You must supply an AQL string");
             });


### PR DESCRIPTION
Within UP4 upwards struts was changed to struts2 and the url "&values" syntax changed from "&values(something)" to "&values['something']". I added a logic statment in to check the qradar build version and set the syntax to use the old struts  "&values(something)" syntax if the build was pre UP4 and if it was UP4 or higher then it used the newer struts2 url syntax of "&values['something']". 